### PR TITLE
feat: add dr submodule with API exposure

### DIFF
--- a/omicverse/llm/dr/__init__.py
+++ b/omicverse/llm/dr/__init__.py
@@ -1,0 +1,12 @@
+"""Domain research utilities for LLM models.
+
+This submodule exposes high-level interfaces like :class:`ResearchManager`.
+"""
+
+try:
+    from .research_manager import ResearchManager
+except Exception:  # pragma: no cover - implementation may be optional
+    ResearchManager = None  # type: ignore
+
+__all__ = ["ResearchManager"]
+


### PR DESCRIPTION
## Summary
- create llm.dr submodule for domain research utilities
- expose ResearchManager as public API

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*


------
https://chatgpt.com/codex/tasks/task_e_68a7aac7d4ec83268d4e04c465fd749c