### PR TITLE
Add scope management utilities

### DIFF
--- a/omicverse/llm/dr/scope/__init__.py
+++ b/omicverse/llm/dr/scope/__init__.py
@@ -1,0 +1,11 @@
+"""Scope management utilities for refining project requirements.
+
+This package provides tools to interactively clarify project scope and
+summarize conversations into concise briefs.
+"""
+
+from .clarifier import Clarifier
+from .brief import BriefGenerator, ProjectBrief
+from .manager import ScopeManager
+
+__all__ = ["Clarifier", "BriefGenerator", "ProjectBrief", "ScopeManager"]

--- a/omicverse/llm/dr/scope/brief.py
+++ b/omicverse/llm/dr/scope/brief.py
@@ -1,0 +1,48 @@
+"""Utilities for condensing dialogue into structured project briefs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+@dataclass
+class ProjectBrief:
+    """Structured representation of a project's requirements."""
+
+    title: str
+    objectives: List[str]
+    constraints: List[str]
+
+
+class BriefGenerator:
+    """Generate a :class:`ProjectBrief` from a dialogue history."""
+
+    def generate(self, dialogue: Sequence[str]) -> ProjectBrief:
+        """Convert dialogue lines into a structured brief.
+
+        Parameters
+        ----------
+        dialogue:
+            Ordered conversation entries.
+
+        Returns
+        -------
+        ProjectBrief
+            The condensed brief containing title, objectives and constraints.
+        """
+        if not dialogue:
+            return ProjectBrief(title="Untitled", objectives=[], constraints=[])
+
+        title = dialogue[0].strip()
+        objectives: List[str] = []
+        constraints: List[str] = []
+
+        for line in dialogue[1:]:
+            cleaned = line.strip()
+            if cleaned.lower().startswith("constraint:"):
+                constraints.append(cleaned.split(":", 1)[1].strip())
+            else:
+                objectives.append(cleaned)
+
+        return ProjectBrief(title=title, objectives=objectives, constraints=constraints)

--- a/omicverse/llm/dr/scope/clarifier.py
+++ b/omicverse/llm/dr/scope/clarifier.py
@@ -1,0 +1,37 @@
+"""Interactive clarification utilities.
+
+The :class:`Clarifier` class assists in refining project scope by generating
+follow-up questions. Each question is returned with a prefix from
+:class:`MessageStandards` to keep messaging consistent across the
+codebase.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from ...utils.message_standards import MessageStandards
+
+
+class Clarifier:
+    """Generate follow-up questions to clarify user intent."""
+
+    def __init__(self) -> None:
+        self.questions: List[str] = []
+
+    def ask(self, question: str) -> str:
+        """Record a question and return a standardized message.
+
+        Parameters
+        ----------
+        question:
+            The question to present to the user.
+
+        Returns
+        -------
+        str
+            The question prefixed with a ``MessageStandards`` message to
+            encourage consistency across interactions.
+        """
+        self.questions.append(question)
+        return f"{MessageStandards.OPERATION_SUCCESS} {question}"

--- a/omicverse/llm/dr/scope/manager.py
+++ b/omicverse/llm/dr/scope/manager.py
@@ -1,0 +1,35 @@
+"""High level manager for refining and summarizing project scope."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .brief import BriefGenerator, ProjectBrief
+from .clarifier import Clarifier
+
+
+class ScopeManager:
+    """Coordinate clarification and brief generation steps."""
+
+    def __init__(self, clarifier: Clarifier | None = None,
+                 brief_generator: BriefGenerator | None = None) -> None:
+        self.clarifier = clarifier or Clarifier()
+        self.brief_generator = brief_generator or BriefGenerator()
+        self.dialogue: List[str] = []
+
+    def add_message(self, message: str) -> None:
+        """Append a message to the dialogue history."""
+        self.dialogue.append(message)
+
+    def ask_clarification(self, question: str) -> str:
+        """Use the clarifier to ask a follow-up question.
+
+        The question is stored in the dialogue for context.
+        """
+        response = self.clarifier.ask(question)
+        self.dialogue.append(question)
+        return response
+
+    def generate_brief(self) -> ProjectBrief:
+        """Create a structured brief from the accumulated dialogue."""
+        return self.brief_generator.generate(self.dialogue)


### PR DESCRIPTION
## Summary
- add Clarifier to pose follow-up questions with MessageStandards
- add BriefGenerator to summarize dialogue into a structured brief
- add ScopeManager to orchestrate clarification and brief generation

## Testing
- `pytest -q` *(fails: module 'pyarrow' has no attribute 'PyExtensionType')*

------
https://chatgpt.com/codex/tasks/task_e_68a7adf051248326b42da6afdb056dd8