### PR TITLE
Add validation and caching to ResearchManager workflow

### DIFF
--- a/omicverse/llm/dr/cache.py
+++ b/omicverse/llm/dr/cache.py
@@ -1,0 +1,27 @@
+"""Caching utilities for the research workflow."""
+
+from functools import lru_cache
+from typing import Callable, Optional
+
+
+def cache(func: Optional[Callable] = None, *, maxsize: int = 128):
+    """Decorator that applies an LRU cache to ``func``.
+
+    Parameters
+    ----------
+    func:
+        The function to decorate. If ``None``, returns a decorator configured
+        with ``maxsize``.
+    maxsize:
+        Maximum size of the underlying cache.
+    """
+
+    def decorator(f: Callable) -> Callable:
+        return lru_cache(maxsize=maxsize)(f)
+
+    if func is not None:
+        return decorator(func)
+    return decorator
+
+
+__all__ = ["cache"]

--- a/omicverse/llm/dr/validation.py
+++ b/omicverse/llm/dr/validation.py
@@ -1,0 +1,25 @@
+"""Utilities for validating queries used in the research pipeline."""
+
+from OvIntelligence.query_manager import QueryManager
+
+
+def validate_query(query: str) -> None:
+    """Validate a query string.
+
+    Parameters
+    ----------
+    query:
+        The query string to validate.
+
+    Raises
+    ------
+    ValueError
+        If the query fails validation checks provided by
+        :class:`OvIntelligence.query_manager.QueryManager`.
+    """
+    valid, message = QueryManager.validate_query(query)
+    if not valid:
+        raise ValueError(message)
+
+
+__all__ = ["validate_query"]


### PR DESCRIPTION
## Summary
- add query validation helper leveraging `OvIntelligence`'s `QueryManager`
- introduce reusable LRU cache decorator
- integrate validation and caching across ResearchManager's scope, research, and write phases

## Testing
- `pytest` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b6abac648326a25ba287dcd587b5