### PR TITLE
Add dynamic research tutorial and tests for LLM workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,30 @@ OmicVerse can be installed via conda or pypi and you need to install `pytorch` a
 You can use `conda install omicverse -c conda-forge` or `pip install -U omicverse` for installation.
 
 Please checkout the documentations and tutorials at [omicverse page](https://starlitnightly.github.io/omicverse/) or [omicverse.readthedocs.io](https://omicverse.readthedocs.io/en/latest/index.html).
+### Research workflow
+
+The `omicverse.llm.dr` submodule offers an end-to-end research pipeline driven by large language models. It scopes a request, gathers findings from a vector store and writes a cited report.
+
+Additional dependencies may be required depending on the chosen model, such as `torch`, `scanpy`, `tdigest`, `peft`, `datasets` and `accelerate`.
+
+```python
+from omicverse.llm.dr import ResearchManager
+
+class DemoStore:
+    def search(self, query):
+        class Doc:
+            def __init__(self, text):
+                self.id = 0
+                self.text = text
+        return [Doc(f"information about {query}")]
+
+rm = ResearchManager(vector_store=DemoStore())
+brief = rm.scope("Demo project")
+findings = rm.research(brief)
+report = rm.write(brief, findings)
+print(report)
+```
+
 
 ## `4` [Data Framework and Reference](#)
 

--- a/omicverse_guide/docs/Tutorials-llm/t_dr.ipynb
+++ b/omicverse_guide/docs/Tutorials-llm/t_dr.ipynb
@@ -1,0 +1,31 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "cells": [
+    {
+      "id": "f7b0dd9c",
+      "cell_type": "markdown",
+      "source": "# Dynamic Research Tutorial\n\nThis notebook demonstrates an end-to-end research workflow using `ResearchManager`.",
+      "metadata": {}
+    },
+    {
+      "id": "878c1c53",
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "source": "from omicverse.llm.dr import ResearchManager\n\nclass DummyStore:\n    def search(self, query):\n        class Doc:\n            def __init__(self, id, text):\n                self.id=id\n                self.text=text\n        return [Doc(1, f\"background on {query}\")]\n\nrm = ResearchManager(vector_store=DummyStore())\nbrief = rm.scope(\"Example project\")\nfindings = rm.research(brief)\nreport = rm.write(brief, findings)\nprint(report)\n",
+      "outputs": []
+    }
+  ]
+}

--- a/tests/llm/test_dr_research.py
+++ b/tests/llm/test_dr_research.py
@@ -1,0 +1,53 @@
+import types, sys, pathlib, importlib
+
+
+def load_components():
+    repo = pathlib.Path(__file__).resolve().parents[2] / "omicverse"
+    omv = types.ModuleType("omicverse"); omv.__path__=[str(repo)]; sys.modules.setdefault("omicverse", omv)
+    llm = types.ModuleType("omicverse.llm"); llm.__path__=[str(repo/"llm")]; sys.modules.setdefault("omicverse.llm", llm)
+    dr = types.ModuleType("omicverse.llm.dr"); dr.__path__=[str(repo/"llm"/"dr")]; sys.modules.setdefault("omicverse.llm.dr", dr)
+    ov = types.ModuleType("OvIntelligence"); sys.modules.setdefault("OvIntelligence", ov)
+    oq = types.ModuleType("OvIntelligence.query_manager")
+    class QM:
+        @staticmethod
+        def validate_query(q):
+            return True, ""
+    oq.QueryManager = QM
+    sys.modules.setdefault("OvIntelligence.query_manager", oq)
+    mf = types.ModuleType("omicverse.llm.model_factory")
+    class DummyFactory:
+        @staticmethod
+        def create_model(*a, **k):
+            return object()
+    mf.ModelFactory = DummyFactory
+    sys.modules["omicverse.llm.model_factory"] = mf
+    rm_module = importlib.import_module("omicverse.llm.dr.research_manager")
+    scope_module = importlib.import_module("omicverse.llm.dr.scope.brief")
+    agent_module = importlib.import_module("omicverse.llm.dr.research.agent")
+    return rm_module.ResearchManager, scope_module.ProjectBrief, agent_module.Finding
+
+
+ResearchManager, ProjectBrief, Finding = load_components()
+
+
+class DummyDoc:
+    def __init__(self, text):
+        self.text = text
+        self.id = "doc"
+
+
+class DummyStore:
+    def search(self, query):
+        return [DummyDoc(f"about {query}")]
+
+
+def test_research_generates_findings():
+    rm = ResearchManager(vector_store=DummyStore())
+    brief = ProjectBrief(title="t", objectives=["topic1"], constraints=[])
+    findings = rm.research(brief)
+    assert len(findings) == 1
+    f = findings[0]
+    assert isinstance(f, Finding)
+    assert f.topic == "topic1"
+    assert f.text == "about topic1"
+    assert f.sources and f.sources[0].content == "about topic1"

--- a/tests/llm/test_dr_scope.py
+++ b/tests/llm/test_dr_scope.py
@@ -1,0 +1,43 @@
+import types, sys, pathlib, importlib
+
+
+def load_components():
+    repo = pathlib.Path(__file__).resolve().parents[2] / "omicverse"
+    omv = types.ModuleType("omicverse"); omv.__path__=[str(repo)]; sys.modules.setdefault("omicverse", omv)
+    llm = types.ModuleType("omicverse.llm"); llm.__path__=[str(repo/"llm")]; sys.modules.setdefault("omicverse.llm", llm)
+    dr = types.ModuleType("omicverse.llm.dr"); dr.__path__=[str(repo/"llm"/"dr")]; sys.modules.setdefault("omicverse.llm.dr", dr)
+    # stub external dependency
+    ov = types.ModuleType("OvIntelligence"); sys.modules.setdefault("OvIntelligence", ov)
+    oq = types.ModuleType("OvIntelligence.query_manager")
+    class QM:
+        @staticmethod
+        def validate_query(q):
+            return True, ""
+    oq.QueryManager = QM
+    sys.modules.setdefault("OvIntelligence.query_manager", oq)
+    mf = types.ModuleType("omicverse.llm.model_factory")
+    class DummyFactory:
+        @staticmethod
+        def create_model(*a, **k):
+            return object()
+    mf.ModelFactory = DummyFactory
+    sys.modules["omicverse.llm.model_factory"] = mf
+    rm_module = importlib.import_module("omicverse.llm.dr.research_manager")
+    scope_module = importlib.import_module("omicverse.llm.dr.scope.brief")
+    return rm_module.ResearchManager, scope_module.ProjectBrief
+
+
+ResearchManager, ProjectBrief = load_components()
+
+
+class DummyStore:
+    def search(self, query):
+        return []
+
+
+def test_scope_returns_brief():
+    rm = ResearchManager(vector_store=DummyStore())
+    brief = rm.scope("Mitochondria study")
+    assert isinstance(brief, ProjectBrief)
+    assert brief.title == "Mitochondria study"
+    assert brief.objectives == []

--- a/tests/llm/test_dr_write.py
+++ b/tests/llm/test_dr_write.py
@@ -1,0 +1,63 @@
+import types, sys, pathlib, importlib
+
+
+def load_components():
+    repo = pathlib.Path(__file__).resolve().parents[2] / "omicverse"
+    omv = types.ModuleType("omicverse"); omv.__path__=[str(repo)]; sys.modules.setdefault("omicverse", omv)
+    llm = types.ModuleType("omicverse.llm"); llm.__path__=[str(repo/"llm")]; sys.modules.setdefault("omicverse.llm", llm)
+    dr = types.ModuleType("omicverse.llm.dr"); dr.__path__=[str(repo/"llm"/"dr")]; sys.modules.setdefault("omicverse.llm.dr", dr)
+    ov = types.ModuleType("OvIntelligence"); sys.modules.setdefault("OvIntelligence", ov)
+    oq = types.ModuleType("OvIntelligence.query_manager")
+    class QM:
+        @staticmethod
+        def validate_query(q):
+            return True, ""
+    oq.QueryManager = QM
+    sys.modules.setdefault("OvIntelligence.query_manager", oq)
+    mf = types.ModuleType("omicverse.llm.model_factory")
+    class DummyFactory:
+        @staticmethod
+        def create_model(*a, **k):
+            return object()
+    mf.ModelFactory = DummyFactory
+    sys.modules["omicverse.llm.model_factory"] = mf
+    rm_module = importlib.import_module("omicverse.llm.dr.research_manager")
+    scope_module = importlib.import_module("omicverse.llm.dr.scope.brief")
+    agent_module = importlib.import_module("omicverse.llm.dr.research.agent")
+    return rm_module.ResearchManager, scope_module.ProjectBrief, agent_module.Finding, agent_module.SourceCitation
+
+
+ResearchManager, ProjectBrief, Finding, SourceCitation = load_components()
+
+
+class DummyDoc:
+    def __init__(self, text, id="1"):
+        self.text = text
+        self.id = id
+
+
+class DummyStore:
+    def search(self, query):
+        return [DummyDoc(f"text about {query}")]
+
+
+def make_rm():
+    return ResearchManager(vector_store=DummyStore())
+
+
+def test_write_composes_report():
+    rm = make_rm()
+    brief = ProjectBrief(title="T", objectives=["topic"], constraints=[])
+    findings = [Finding(topic="topic", text="summary", sources=[SourceCitation(source_id="1", content="ref")])]
+    report = rm.write(brief, findings)
+    assert "topic" in report
+    assert "ref" in report
+
+
+def test_run_pipeline(monkeypatch):
+    rm = make_rm()
+    monkeypatch.setattr(rm.scope_manager, "generate_brief", lambda: ProjectBrief(title="T", objectives=["topic"], constraints=[]))
+    report = rm.run("T")
+    assert "topic" in report
+    assert "text about topic" in report
+    assert "[1]" in report


### PR DESCRIPTION
## Summary
- Document LLM-driven research workflow with usage and dependency notes
- Provide notebook demonstrating an end-to-end research pipeline
- Add tests covering scope, research, writing, and full run of `ResearchManager`

## Testing
- `pytest tests/llm/test_dr_scope.py tests/llm/test_dr_research.py tests/llm/test_dr_write.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7b9f536048326b5920639342ed981