### PR TITLE
Stabilize external API clients: EMDB, Reactome, Paleobiology, MPD, gn…

### DIFF
--- a/omicverse/external/datacollect/api/emdb.py
+++ b/omicverse/external/datacollect/api/emdb.py
@@ -229,4 +229,12 @@ class EMDBClient(BaseAPIClient):
         Returns:
             Database statistics
         """
-        return self.get("/api/statistics").json()
+        resp = self.get("/api/statistics")
+        ctype = (resp.headers.get("content-type") or "").lower()
+        if "application/json" in ctype:
+            try:
+                return resp.json()
+            except Exception:
+                pass
+        # Fallback when service returns HTML/text
+        return {"raw": resp.text}

--- a/omicverse/external/datacollect/api/expression/opentargets_genetics.py
+++ b/omicverse/external/datacollect/api/expression/opentargets_genetics.py
@@ -3,6 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 import json
+import time
+import requests
 
 from ..base import BaseAPIClient
 from ...config import settings
@@ -50,13 +52,20 @@ class OpenTargetsGeneticsClient(BaseAPIClient):
         if variables:
             payload["variables"] = variables
         
-        response = self.session.post(
-            self.base_url,
-            json=payload,
-            headers=self.get_default_headers()
-        )
-        response.raise_for_status()
-        return response.json()
+        last_err = None
+        for attempt in range(3):
+            try:
+                response = self.session.post(
+                    self.base_url,
+                    json=payload,
+                    headers=self.get_default_headers()
+                )
+                response.raise_for_status()
+                return response.json()
+            except requests.exceptions.RequestException as e:
+                last_err = e
+                time.sleep(1.0 * (attempt + 1))
+        raise last_err
     
     def get_gene_info(self, gene_id: str) -> Dict[str, Any]:
         """Get gene information.

--- a/omicverse/external/datacollect/api/gnomad.py
+++ b/omicverse/external/datacollect/api/gnomad.py
@@ -2,6 +2,8 @@
 
 import logging
 from typing import Any, Dict, List, Optional
+import time
+import requests
 import json
 
 from .base import BaseAPIClient
@@ -51,13 +53,30 @@ class GnomADClient(BaseAPIClient):
         if variables:
             payload["variables"] = variables
         
-        response = self.session.post(
-            self.base_url,
-            json=payload,
-            headers=self.get_default_headers()
-        )
-        response.raise_for_status()
-        return response.json()
+        last_err = None
+        for attempt in range(3):
+            try:
+                response = self.session.post(
+                    self.base_url,
+                    json=payload,
+                    headers=self.get_default_headers()
+                )
+                try:
+                    response.raise_for_status()
+                except requests.exceptions.HTTPError as e:
+                    # Attach response body for easier debugging
+                    body = ""
+                    try:
+                        body = response.text[:1000]
+                    except Exception:
+                        pass
+                    raise requests.exceptions.HTTPError(f"{e}; body: {body}") from e
+                return response.json()
+            except requests.exceptions.RequestException as e:
+                last_err = e
+                time.sleep(1.0 * (attempt + 1))
+        # Exhausted retries
+        raise last_err
     
     def get_gene(self, gene_symbol: str, dataset: str = "gnomad_r3") -> Dict[str, Any]:
         """Get gene information and variants.

--- a/omicverse/external/datacollect/api/mpd.py
+++ b/omicverse/external/datacollect/api/mpd.py
@@ -1,6 +1,7 @@
 """Mouse Phenome Database API client."""
 
 from typing import Dict, List, Optional, Any
+import requests
 from .base import BaseAPIClient
 
 
@@ -69,8 +70,26 @@ class MPDClient(BaseAPIClient):
         if panel:
             params["panel"] = panel
         
-        response = self.get("/api/strains/search", params=params)
-        return response.json().get("strains", [])
+        try:
+            response = self.get("/api/strains/search", params=params)
+            data = response.json()
+            # Newer API may return list directly
+            return data.get("strains", data if isinstance(data, list) else [])
+        except requests.exceptions.HTTPError as e:
+            status = getattr(e.response, "status_code", None)
+            # Try alternative endpoints if route changed
+            for alt in ("/api/strains", "/api/strain/search"):
+                try:
+                    resp = self.get(alt, params=params)
+                    try:
+                        data = resp.json()
+                    except Exception:
+                        data = []
+                    return data.get("strains", data if isinstance(data, list) else [])
+                except requests.exceptions.HTTPError:
+                    continue
+            # If all fail, bubble original error
+            raise
     
     def get_strain_info(self, strain_name: str) -> Dict[str, Any]:
         """

--- a/omicverse/external/datacollect/api/paleobiology.py
+++ b/omicverse/external/datacollect/api/paleobiology.py
@@ -47,7 +47,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["continent"] = continent
         
         response = self.get("/occs/list.json", params=params)
-        return response
+        # Return parsed JSON directly
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_occurrences(
         self,
@@ -81,7 +85,12 @@ class PaleobiologyClient(BaseAPIClient):
             params["cc"] = country
         
         response = self.get("/occs/list.json", params=params)
-        return response.get("records", [])
+        data = {}
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def search_occurrences(
         self,
@@ -108,13 +117,21 @@ class PaleobiologyClient(BaseAPIClient):
         if country:
             params["cc"] = country
         
-        return self.get("/occs/list.json", params=params)
+        response = self.get("/occs/list.json", params=params)
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_occurrence(self, occurrence_id: str) -> Dict[str, Any]:
         """Get single occurrence by ID."""
         params = {"id": occurrence_id, "show": "full"}
         response = self.get("/occs/single.json", params=params)
-        return response.get("records", [{}])[0] if response.get("records") else {}
+        try:
+            data = response.json()
+        except Exception:
+            return {}
+        return data.get("records", [{}])[0] if data.get("records") else {}
     
     def get_taxa(
         self,
@@ -144,7 +161,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["extant"] = "no" if extinct else "yes"
         
         response = self.get("/taxa/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def search_taxa(
         self,
@@ -168,13 +189,21 @@ class PaleobiologyClient(BaseAPIClient):
         if extinct is not None:
             params["extant"] = "no" if extinct else "yes"
         
-        return self.get("/taxa/list.json", params=params)
+        response = self.get("/taxa/list.json", params=params)
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_taxon(self, taxon_id: str) -> Dict[str, Any]:
         """Get single taxon by ID."""
         params = {"id": taxon_id, "show": "full"}
         response = self.get("/taxa/single.json", params=params)
-        return response.get("records", [{}])[0] if response.get("records") else {}
+        try:
+            data = response.json()
+        except Exception:
+            return {}
+        return data.get("records", [{}])[0] if data.get("records") else {}
     
     def get_collections(
         self,
@@ -203,7 +232,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["cc"] = country
         
         response = self.get("/colls/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def search_collections(
         self,
@@ -227,13 +260,21 @@ class PaleobiologyClient(BaseAPIClient):
         if country:
             params["cc"] = country
         
-        return self.get("/colls/list.json", params=params)
+        response = self.get("/colls/list.json", params=params)
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_collection(self, collection_id: str) -> Dict[str, Any]:
         """Get single collection by ID."""
         params = {"id": collection_id, "show": "full"}
         response = self.get("/colls/single.json", params=params)
-        return response.get("records", [{}])[0] if response.get("records") else {}
+        try:
+            data = response.json()
+        except Exception:
+            return {}
+        return data.get("records", [{}])[0] if data.get("records") else {}
     
     def get_time_intervals(self) -> List[Dict[str, Any]]:
         """
@@ -244,7 +285,11 @@ class PaleobiologyClient(BaseAPIClient):
         """
         params = {"scale": "all"}
         response = self.get("/intervals/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def get_intervals(
         self,
@@ -260,7 +305,11 @@ class PaleobiologyClient(BaseAPIClient):
         if max_age:
             params["max_ma"] = max_age
         
-        return self.get("/intervals/list.json", params=params)
+        response = self.get("/intervals/list.json", params=params)
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_diversity(
         self,
@@ -289,7 +338,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["interval"] = interval
         
         response = self.get("/occs/diversity.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def get_references(
         self,
@@ -314,7 +367,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["year"] = year
         
         response = self.get("/refs/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def get_measurements(
         self,
@@ -337,7 +394,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["meas_type"] = measurement_type
         
         response = self.get("/specs/measurements.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def get_strata(
         self,
@@ -362,4 +423,8 @@ class PaleobiologyClient(BaseAPIClient):
             params["rank"] = rank
         
         response = self.get("/strata/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])

--- a/omicverse/external/datacollect/api/proteins/emdb.py
+++ b/omicverse/external/datacollect/api/proteins/emdb.py
@@ -227,4 +227,11 @@ class EMDBClient(BaseAPIClient):
         Returns:
             Database statistics
         """
-        return self.get("/api/statistics").json()
+        resp = self.get("/api/statistics")
+        ctype = (resp.headers.get("content-type") or "").lower()
+        if "application/json" in ctype:
+            try:
+                return resp.json()
+            except Exception:
+                pass
+        return {"raw": resp.text}

--- a/omicverse/external/datacollect/api/specialized/mpd.py
+++ b/omicverse/external/datacollect/api/specialized/mpd.py
@@ -1,6 +1,7 @@
 """Mouse Phenome Database API client."""
 
 from typing import Dict, List, Optional, Any
+import requests
 from ..base import BaseAPIClient
 
 
@@ -69,8 +70,23 @@ class MPDClient(BaseAPIClient):
         if panel:
             params["panel"] = panel
         
-        response = self.get("/api/strains/search", params=params)
-        return response.json().get("strains", [])
+        try:
+            response = self.get("/api/strains/search", params=params)
+            data = response.json()
+            return data.get("strains", data if isinstance(data, list) else [])
+        except requests.exceptions.HTTPError:
+            # Try alternative endpoints if route changed
+            for alt in ("/api/strains", "/api/strain/search"):
+                try:
+                    resp = self.get(alt, params=params)
+                    try:
+                        data = resp.json()
+                    except Exception:
+                        data = []
+                    return data.get("strains", data if isinstance(data, list) else [])
+                except requests.exceptions.HTTPError:
+                    continue
+            raise
     
     def get_strain_info(self, strain_name: str) -> Dict[str, Any]:
         """

--- a/omicverse/external/datacollect/api/specialized/paleobiology.py
+++ b/omicverse/external/datacollect/api/specialized/paleobiology.py
@@ -47,7 +47,10 @@ class PaleobiologyClient(BaseAPIClient):
             params["continent"] = continent
         
         response = self.get("/occs/list.json", params=params)
-        return response
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_occurrences(
         self,
@@ -81,7 +84,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["cc"] = country
         
         response = self.get("/occs/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def search_occurrences(
         self,
@@ -108,13 +115,21 @@ class PaleobiologyClient(BaseAPIClient):
         if country:
             params["cc"] = country
         
-        return self.get("/occs/list.json", params=params)
+        response = self.get("/occs/list.json", params=params)
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_occurrence(self, occurrence_id: str) -> Dict[str, Any]:
         """Get single occurrence by ID."""
         params = {"id": occurrence_id, "show": "full"}
         response = self.get("/occs/single.json", params=params)
-        return response.get("records", [{}])[0] if response.get("records") else {}
+        try:
+            data = response.json()
+        except Exception:
+            return {}
+        return data.get("records", [{}])[0] if data.get("records") else {}
     
     def get_taxa(
         self,
@@ -144,7 +159,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["extant"] = "no" if extinct else "yes"
         
         response = self.get("/taxa/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def search_taxa(
         self,
@@ -168,13 +187,21 @@ class PaleobiologyClient(BaseAPIClient):
         if extinct is not None:
             params["extant"] = "no" if extinct else "yes"
         
-        return self.get("/taxa/list.json", params=params)
+        response = self.get("/taxa/list.json", params=params)
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_taxon(self, taxon_id: str) -> Dict[str, Any]:
         """Get single taxon by ID."""
         params = {"id": taxon_id, "show": "full"}
         response = self.get("/taxa/single.json", params=params)
-        return response.get("records", [{}])[0] if response.get("records") else {}
+        try:
+            data = response.json()
+        except Exception:
+            return {}
+        return data.get("records", [{}])[0] if data.get("records") else {}
     
     def get_collections(
         self,
@@ -203,7 +230,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["cc"] = country
         
         response = self.get("/colls/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def search_collections(
         self,
@@ -227,13 +258,21 @@ class PaleobiologyClient(BaseAPIClient):
         if country:
             params["cc"] = country
         
-        return self.get("/colls/list.json", params=params)
+        response = self.get("/colls/list.json", params=params)
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_collection(self, collection_id: str) -> Dict[str, Any]:
         """Get single collection by ID."""
         params = {"id": collection_id, "show": "full"}
         response = self.get("/colls/single.json", params=params)
-        return response.get("records", [{}])[0] if response.get("records") else {}
+        try:
+            data = response.json()
+        except Exception:
+            return {}
+        return data.get("records", [{}])[0] if data.get("records") else {}
     
     def get_time_intervals(self) -> List[Dict[str, Any]]:
         """
@@ -244,7 +283,11 @@ class PaleobiologyClient(BaseAPIClient):
         """
         params = {"scale": "all"}
         response = self.get("/intervals/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def get_intervals(
         self,
@@ -260,7 +303,11 @@ class PaleobiologyClient(BaseAPIClient):
         if max_age:
             params["max_ma"] = max_age
         
-        return self.get("/intervals/list.json", params=params)
+        response = self.get("/intervals/list.json", params=params)
+        try:
+            return response.json()
+        except Exception:
+            return {"raw": response.text}
     
     def get_diversity(
         self,
@@ -289,7 +336,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["interval"] = interval
         
         response = self.get("/occs/diversity.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def get_references(
         self,
@@ -314,7 +365,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["year"] = year
         
         response = self.get("/refs/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def get_measurements(
         self,
@@ -337,7 +392,11 @@ class PaleobiologyClient(BaseAPIClient):
             params["meas_type"] = measurement_type
         
         response = self.get("/specs/measurements.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])
     
     def get_strata(
         self,
@@ -362,4 +421,8 @@ class PaleobiologyClient(BaseAPIClient):
             params["rank"] = rank
         
         response = self.get("/strata/list.json", params=params)
-        return response.get("records", [])
+        try:
+            data = response.json()
+        except Exception:
+            return []
+        return data.get("records", [])


### PR DESCRIPTION
…omAD, OT Genetics

- EMDB: guard JSON parsing; fallback to raw when non-JSON
- Reactome: fall back to /search/query when direct gene-pathways call not 200
- Paleobiology: correctly parse JSON (avoid Response.get), return []/raw safely
- MPD: add fallback endpoints for strains search when legacy route 404s
- gnomAD: add retries and include response body on HTTP 400
- OpenTargets Genetics: add simple retry/backoff for transient DNS issues

Includes corresponding updates under proteins/pathways/specialized/genomics/expression packages.